### PR TITLE
feat: rename to npm compliant name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-![Maintenance score](https://img.shields.io/npms-io/maintenance-score/@asyncapi/EDAVisualiser)
-[![Npm latest version](https://img.shields.io/npm/v/@asyncapi/EDAVisualiser)](https://www.npmjs.com/package/@asyncapi/EDAVisualiser)
+![Maintenance score](https://img.shields.io/npms-io/maintenance-score/@asyncapi/edavisualiser)
+[![Npm latest version](https://img.shields.io/npm/v/@asyncapi/edavisualiser)](https://www.npmjs.com/package/@asyncapi/edavisualiser)
 [![License](https://img.shields.io/github/license/asyncapi/EDAVisualiser)](https://github.com/asyncapi/EDAVisualiser/blob/master/LICENSE)
 [![last commit](https://img.shields.io/github/last-commit/asyncapi/EDAVisualiser)](https://github.com/asyncapi/EDAVisualiser/commits/master)
 [![Playground](https://img.shields.io/website?label=playground&url=https%3A%2F%asyncapi.github.io%2FEDAVisualiser)](https://asyncapi.github.io/EDAVisualiser) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
@@ -42,7 +42,7 @@ It is written in React, however, it also supports the most used frameworks such 
 Run this command to install the visualizer in your project:
 
 ```bash
-npm install @asyncapi/EDAVisualiser
+npm install @asyncapi/edavisualiser
 ```
 
 ## Inputs

--- a/examples/angular/angular.json
+++ b/examples/angular/angular.json
@@ -28,7 +28,7 @@
             ],
             "styles": [
               "src/styles.css",
-              "node_modules/@asyncapi/EDAVisualiser/styles/default.min.css"
+              "node_modules/@asyncapi/edavisualiser/styles/default.min.css"
             ],
             "scripts": []
           },

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "dependencies": {
-    "@asyncapi/EDAVisualiser": "0.10.0",
+    "@asyncapi/edavisualiser": "0.10.0",
     "@angular/animations": "~13.3.0",
     "@angular/common": "~13.3.0",
     "@angular/compiler": "~13.3.0",

--- a/examples/angular/src/app/Edavisualiser.d.ts
+++ b/examples/angular/src/app/Edavisualiser.d.ts
@@ -1,1 +1,1 @@
-declare module '@asyncapi/EDAVisualiser/browser/standalone';
+declare module '@asyncapi/edavisualiser/browser/standalone';

--- a/examples/angular/src/app/applicationview.component.ts
+++ b/examples/angular/src/app/applicationview.component.ts
@@ -1,12 +1,12 @@
 import { Component, ElementRef, OnDestroy, AfterViewInit, } from '@angular/core';
-import StandaloneRenderer from "@asyncapi/EDAVisualiser/browser/standalone";
+import StandaloneRenderer from "@asyncapi/edavisualiser/browser/standalone";
 
 @Component({
   selector: 'app-root',
   template: `
     <div style="width:100vw;height:100vh;" id="asyncapi-doc"></div>
   `,
-  styleUrls: ['../../node_modules/@asyncapi/EDAVisualiser/styles/default.min.css']
+  styleUrls: ['../../node_modules/@asyncapi/edavisualiser/styles/default.min.css']
 }) 
 export class ApplicationViewComponent implements OnDestroy, AfterViewInit {
   constructor(private element: ElementRef) {}

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "hasInstallScript": true,
       "dependencies": {
-        "@asyncapi/EDAVisualiser": "0.15.0",
+        "@asyncapi/edavisualiser": "0.15.0",
         "next": "^10.0.0"
       }
     },
@@ -140,9 +140,9 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
-    "node_modules/@asyncapi/EDAVisualiser": {
+    "node_modules/@asyncapi/edavisualiser": {
       "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/EDAVisualiser/-/edavisualiser-0.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@asyncapi/edavisualiser/-/edavisualiser-0.15.0.tgz",
       "integrity": "sha512-zND1iLAFy0IvX8luKikbxr2Ax8UEXNoL+OvEjoty9S2A3nBhkmCKy8ZbfRD6hMH9qZXpE9NW8fO3M5l7+xfAIA==",
       "dependencies": {
         "@asyncapi/parser": "^1.15.0",
@@ -5181,9 +5181,9 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
-    "@asyncapi/EDAVisualiser": {
+    "@asyncapi/edavisualiser": {
       "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/EDAVisualiser/-/edavisualiser-0.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@asyncapi/edavisualiser/-/edavisualiser-0.15.0.tgz",
       "integrity": "sha512-zND1iLAFy0IvX8luKikbxr2Ax8UEXNoL+OvEjoty9S2A3nBhkmCKy8ZbfRD6hMH9qZXpE9NW8fO3M5l7+xfAIA==",
       "requires": {
         "@asyncapi/parser": "^1.15.0",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -7,7 +7,7 @@
     "postinstall": "npm link ../../library/node_modules/react-dom ../../library/node_modules/react ../../library/"
   },
   "dependencies": {
-    "@asyncapi/EDAVisualiser": "0.15.0",
+    "@asyncapi/edavisualiser": "0.15.0",
     "next": "^10.0.0"
   }
 }

--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -1,4 +1,4 @@
-import '@asyncapi/EDAVisualiser/styles/default.css';
+import '@asyncapi/edavisualiser/styles/default.css';
 
 function MyApp({ Component, pageProps }) {
   return <Component {...pageProps} />

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -1,4 +1,4 @@
-import { ApplicationView } from '@asyncapi/EDAVisualiser';
+import { ApplicationView } from '@asyncapi/edavisualiser';
 
 function App() {
   // Render on the browser only

--- a/examples/simple-react/package-lock.json
+++ b/examples/simple-react/package-lock.json
@@ -1769,9 +1769,9 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
-    "@asyncapi/EDAVisualiser": {
+    "@asyncapi/edavisualiser": {
       "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/EDAVisualiser/-/edavisualiser-0.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/@asyncapi/edavisualiser/-/edavisualiser-0.15.1.tgz",
       "integrity": "sha512-iVRjnhQenpLfQwF4kKnFjaRK5Q3/VbamiAXc3ghMRLn29Yczw3m0HyY+D6p2n4e/vMeZ7jZTMUPWV271864ePA==",
       "requires": {
         "@asyncapi/parser": "^1.15.0",

--- a/examples/simple-react/package.json
+++ b/examples/simple-react/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@asyncapi/parser": "^1.15.0",
-    "@asyncapi/EDAVisualiser": "^0.15.0",
+    "@asyncapi/edavisualiser": "^0.15.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-router-dom": "^5.3.0",

--- a/examples/simple-react/src/SimpleApp.tsx
+++ b/examples/simple-react/src/SimpleApp.tsx
@@ -1,5 +1,5 @@
-import { ApplicationView } from '@asyncapi/EDAVisualiser';
-import '@asyncapi/EDAVisualiser/styles/default.css';
+import { ApplicationView } from '@asyncapi/edavisualiser';
+import '@asyncapi/edavisualiser/styles/default.css';
 
 function App() {
   return (

--- a/examples/simple-react/src/SimpleAsyncapi.tsx
+++ b/examples/simple-react/src/SimpleAsyncapi.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { ApplicationView } from '@asyncapi/EDAVisualiser';
-import '@asyncapi/EDAVisualiser/styles/default.css';
+import { ApplicationView } from '@asyncapi/edavisualiser';
+import '@asyncapi/edavisualiser/styles/default.css';
 import '@asyncapi/parser/dist/bundle';
 
 const asyncAPIDocument = `

--- a/examples/simple-react/src/SimpleSystem.tsx
+++ b/examples/simple-react/src/SimpleSystem.tsx
@@ -1,4 +1,4 @@
-import { SystemView } from '@asyncapi/EDAVisualiser';
+import { SystemView } from '@asyncapi/edavisualiser';
 
 function App() {
   return (

--- a/examples/simple-react/src/gamingapi/System.tsx
+++ b/examples/simple-react/src/gamingapi/System.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
-import { SystemView } from '@asyncapi/EDAVisualiser';
+import { SystemView } from '@asyncapi/edavisualiser';
 import { apps } from './apps';
 import '@asyncapi/parser/dist/bundle';
-import '@asyncapi/EDAVisualiser/styles/default.css';
+import '@asyncapi/edavisualiser/styles/default.css';
 
 function Asyncapi() {
   const [asyncapiDocuments, setAsyncapiDocuments] = useState<Array<{ parsedDoc: any, name: string }>>([]);

--- a/examples/simple-react/src/gamingapi/application.tsx
+++ b/examples/simple-react/src/gamingapi/application.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { ApplicationFocusView } from '@asyncapi/EDAVisualiser';
+import { ApplicationFocusView } from '@asyncapi/edavisualiser';
 import '@asyncapi/parser/dist/bundle';
 import { apps } from './apps';
-import '@asyncapi/EDAVisualiser/styles/default.css';
+import '@asyncapi/edavisualiser/styles/default.css';
 
 function Asyncapi() {
   const [externalApplications, setAsyncapiDocuments] = useState<Array<{ parsedDoc: any, name: string }>>([]);

--- a/examples/simple-react/src/index.tsx
+++ b/examples/simple-react/src/index.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { App } from './App';
 
 import './index.css';
-import '@asyncapi/EDAVisualiser/styles/default.css';
+import '@asyncapi/edavisualiser/styles/default.css';
 
 ReactDOM.render(
   <React.StrictMode>

--- a/examples/simple-react/src/social_media/System.tsx
+++ b/examples/simple-react/src/social_media/System.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
-import { SystemView } from '@asyncapi/EDAVisualiser';
+import { SystemView } from '@asyncapi/edavisualiser';
 import { Menu } from './menu';
 import { apps } from './apps';
 import '@asyncapi/parser/dist/bundle';
-import '@asyncapi/EDAVisualiser/styles/default.css';
+import '@asyncapi/edavisualiser/styles/default.css';
 
 function Asyncapi() {
   const [asyncapiDocuments, setAsyncapiDocuments] = useState<Array<{ parsedDoc: any, name: string }>>([]);

--- a/examples/simple-react/src/social_media/application.tsx
+++ b/examples/simple-react/src/social_media/application.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
 import { Menu } from './menu';
 import { useParams } from 'react-router-dom';
-import { ApplicationFocusView } from '@asyncapi/EDAVisualiser';
+import { ApplicationFocusView } from '@asyncapi/edavisualiser';
 import { apps } from './apps';
 import '@asyncapi/parser/dist/bundle';
 
-import '@asyncapi/EDAVisualiser/styles/default.css';
+import '@asyncapi/edavisualiser/styles/default.css';
 
 function Asyncapi() {
   const [externalApplications, setAsyncapiDocuments] = useState<Array<{ parsedDoc: any, name: string }>>([]);

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -6,14 +6,14 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "copy:styles": "cp ./node_modules/@asyncapi/EDAVisualiser/styles/default.min.css ./src/assets/edavisualiser.min.css"
+    "copy:styles": "cp ./node_modules/@asyncapi/edavisualiser/styles/default.min.css ./src/assets/edavisualiser.min.css"
   },
   "dependencies": {
     "core-js": "^3.8.3",
     "vue": "^3.2.13"
   },
   "devDependencies": {
-    "@asyncapi/EDAVisualiser": "0.10.0",
+    "@asyncapi/edavisualiser": "0.10.0",
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.12.16",
     "@vue/cli-plugin-babel": "~5.0.0",

--- a/examples/vue/src/ApplicationView.vue
+++ b/examples/vue/src/ApplicationView.vue
@@ -4,7 +4,7 @@
 </template>
 
 <script>
-import StandaloneRenderer from '@asyncapi/EDAVisualiser/browser/standalone'
+import StandaloneRenderer from '@asyncapi/edavisualiser/browser/standalone'
 const props = {
   application: {
     id: "string",

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@asyncapi/EDAVisualiser",
+  "name": "@asyncapi/edavisualiser",
   "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/library/package.json
+++ b/library/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@asyncapi/EDAVisualiser",
+  "name": "@asyncapi/edavisualiser",
   "version": "1.0.1",
   "private": false,
   "description": "A React flow library for visualizing event driven architectures.",


### PR DESCRIPTION
**Description**
As the last release failed, we have to rename it to be npm compliant.
https://github.com/asyncapi/EDAVisualiser/actions/runs/3468692839/jobs/5794910494
